### PR TITLE
Add OptiGUI support

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -18,5 +18,21 @@
     "fabric": "*",
     "minecraft": "1.20.x",
     "java": ">=17"
+  },
+  "custom": {
+    "optigui": {
+      "containerTextures": {
+        "variantcartographytables:acacia_cartography_table": "minecraft:textures/gui/container/cartography_table.png",
+        "variantcartographytables:bamboo_cartography_table": "minecraft:textures/gui/container/cartography_table.png",
+        "variantcartographytables:birch_cartography_table": "minecraft:textures/gui/container/cartography_table.png",
+        "variantcartographytables:cherry_cartography_table": "minecraft:textures/gui/container/cartography_table.png",
+        "variantcartographytables:crimson_cartography_table": "minecraft:textures/gui/container/cartography_table.png",
+        "variantcartographytables:jungle_cartography_table": "minecraft:textures/gui/container/cartography_table.png",
+        "variantcartographytables:mangrove_cartography_table": "minecraft:textures/gui/container/cartography_table.png",
+        "variantcartographytables:oak_cartography_table": "minecraft:textures/gui/container/cartography_table.png",
+        "variantcartographytables:spruce_cartography_table": "minecraft:textures/gui/container/cartography_table.png",
+        "variantcartographytables:warped_cartography_table": "minecraft:textures/gui/container/cartography_table.png"
+      }
+    }
   }
 }


### PR DESCRIPTION
Add the required metadata so OptiGUI 2.2.0-alpha.1+ will recognize the variant cartography tables (yes, I have tested it, and it worked).